### PR TITLE
fix: import AliasPlugin locally

### DIFF
--- a/aldryn_forms/helpers.py
+++ b/aldryn_forms/helpers.py
@@ -1,6 +1,3 @@
-from cms.cms_plugins import AliasPlugin
-
-
 def get_user_name(user):
     try:
         name = user.get_full_name()
@@ -12,6 +9,7 @@ def get_user_name(user):
 
 def is_form_element(plugin):
     # import here due because of circular imports
+    from cms.cms_plugins import AliasPlugin
     from .cms_plugins import FormElement
 
     # cms_plugins.CMSPlugin subclass

--- a/aldryn_forms/models.py
+++ b/aldryn_forms/models.py
@@ -12,7 +12,6 @@ from django.db.models.functions import Coalesce
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
-from cms.cms_plugins import AliasPlugin
 from cms.models.fields import PageField
 from cms.models.pluginmodel import CMSPlugin
 from cms.utils.plugins import downcast_plugins
@@ -255,6 +254,7 @@ class BaseFormPlugin(CMSPlugin):
         return
 
     def get_form_fields(self) -> List[FormField]:
+        from cms.cms_plugins import AliasPlugin
         from .cms_plugins import Field
 
         fields = []

--- a/aldryn_forms/utils.py
+++ b/aldryn_forms/utils.py
@@ -8,7 +8,6 @@ from django.forms.forms import NON_FIELD_ERRORS
 from django.utils.module_loading import import_string
 from django.utils.translation import get_language
 
-from cms.cms_plugins import AliasPlugin
 from cms.utils.moderator import get_cmsplugin_queryset
 from cms.utils.plugins import downcast_plugins
 
@@ -91,6 +90,8 @@ def get_nested_plugins(parent_plugin, include_self=False):
     """
     Returns a flat list of plugins from parent_plugin. Replace AliasPlugin by descendants.
     """
+    from cms.cms_plugins import AliasPlugin
+
     found_plugins = []
 
     if include_self:


### PR DESCRIPTION
this prevents aldryn_forms' initialization from failing with 'RuntimeError: dictionary size changed during iteration' in certain existing codebases still running under django CMS 3.

Installing this branch into our codebase and testing our existing forms worked properly.